### PR TITLE
Actually use SITEMAP_INDEX_NAME from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,27 +86,46 @@ Working example is in `testproject.testapp`.
     ```python
     INSTALLED_APPS.append('sitemap_generate')
     ```
+
 2. Add a reference to sitemap mapping to django settings:
     ```python
     SITEMAP_MAPPING = 'testproject.testapp.urls.sitemaps'
     ```
+
 3. Specify name of the sitemap index url. If you have `urlpatterns` like
    example above, you can write:
     ```python
     SITEMAP_INDEX_NAME = 'sitemap-index'
     ```
+   default: `'sitemap-index'`
+
 4. Specify name of the `view.sitemap` view. If you have `urlpatterns` like
    example above, you can write:
     ```python
     SITEMAPS_VIEW_NAME = 'django.contrib.sitemaps.views.sitemap'
     ```
-5. Also you may need to setup forwarded protocol handling in django settings:
+   default: `'django.contrib.sitemaps.views.sitemap'`
+
+5. Set media path to store sitemaps under
+    ```python
+    SITEMAP_MEDIA_PATH = 'sitemaps'
+    ```
+   default: `'sitemaps'`
+
+6. Also you may need to setup forwarded protocol handling in django settings:
     ```python
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
     ```
-6. Note that django paginates sitemap with `p` query parameter, but 
+
+7. Note that django paginates sitemap with `p` query parameter, but 
     corresponding sitemap files are named `sitemap-video.xml`, 
     `sitemap-video-2.xml` and so on. You'll need to configure some "rewrites".
+
+8. Optional. Change storage for generated sitemaps
+    ```python
+    SITEMAP_STORAGE = custom_storage
+    ```
+   default: `django.core.files.storage.default_storage`
     
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -90,15 +90,21 @@ Working example is in `testproject.testapp`.
     ```python
     SITEMAP_MAPPING = 'testproject.testapp.urls.sitemaps'
     ```
-3. You may need to override default sitemap index url name
+3. Specify name of the sitemap index url. If you have `urlpatterns` like
+   example above, you can write:
     ```python
-    SITEMAP_INDEX_URL = 'sitemap-index'
+    SITEMAP_INDEX_NAME = 'sitemap-index'
     ```
-4. Also you may need to setup forwarded protocol handling in django settings:
+4. Specify name of the `view.sitemap` view. If you have `urlpatterns` like
+   example above, you can write:
+    ```python
+    SITEMAPS_VIEW_NAME = 'django.contrib.sitemaps.views.sitemap'
+    ```
+5. Also you may need to setup forwarded protocol handling in django settings:
     ```python
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
     ```
-5. Note that django paginates sitemap with `p` query parameter, but 
+6. Note that django paginates sitemap with `p` query parameter, but 
     corresponding sitemap files are named `sitemap-video.xml`, 
     `sitemap-video-2.xml` and so on. You'll need to configure some "rewrites".
     
@@ -133,7 +139,7 @@ You may run sitemap generation from celery:
 ```python 
 @celery.task
 def generate_sitemap():
-    generator = SitemapGenerator(sitemaps={'video': VideoSitemap)
+    generator = SitemapGenerator() # Uses django settings by default
     generator.generate()
 ```
 

--- a/sitemap_generate/default_settings.py
+++ b/sitemap_generate/default_settings.py
@@ -1,0 +1,14 @@
+from django.core.files.storage import default_storage
+
+
+# Default directory in media storage where sitemaps are stored
+SITEMAP_MEDIA_PATH = 'sitemaps'
+
+# Default media storage for sitemaps
+SITEMAP_STORAGE = default_storage
+
+# Default name of sitemap index view
+SITEMAP_INDEX_NAME = 'sitemap-index'
+
+# Default name of sitemaps view
+SITEMAPS_VIEW_NAME = 'django.contrib.sitemaps.views.sitemap'

--- a/sitemap_generate/generator.py
+++ b/sitemap_generate/generator.py
@@ -1,15 +1,17 @@
 import os
 from io import StringIO
 from logging import getLogger
-from typing import Dict, Optional, Callable, Type
+from typing import Callable, Dict, Optional, Type
 from urllib.parse import ParseResult, urlparse
 
+from django.conf import settings
 from django.contrib.sitemaps import Sitemap
 from django.core.files.base import ContentFile
-from django.core.files.storage import default_storage, Storage
+from django.core.files.storage import Storage, default_storage
 from django.core.servers import basehttp
 from django.http import HttpResponse
 from django.urls import reverse
+from django.utils.module_loading import import_string
 
 from sitemap_generate import defaults
 
@@ -81,21 +83,40 @@ class SitemapGenerator:
     def __init__(self,
                  media_path: str = 'sitemaps',
                  storage: Storage = default_storage,
-                 index_url_name: str = 'sitemap-index',
+                 index_url_name: Optional[str] = None,
+                 sitemaps_view_name: Optional[str] = None,
                  sitemaps: Optional[Dict[str, Type[Sitemap]]] = None):
         """
 
         :param media_path: relative path on file storage
         :param storage: file storage implementation used for sitemaps
         :param index_url_name: name of view serving sitemap index xml file
+        :param sitemaps_view_name: name of view serving indexed sitemaps
         :param sitemaps: mapping: sitemap name -> sitemap implementation
         """
         cls = self.__class__
         self.logger = getLogger(f'{cls.__module__}.{cls.__name__}')
         self.sitemap_root = media_path
         self.storage = storage
-        self.index_url_name = index_url_name
-        self.sitemaps = sitemaps or {}
+        self.index_url_name = (
+            index_url_name
+            if index_url_name is not None
+            else getattr(settings, 'SITEMAP_INDEX_NAME', 'sitemap-index')
+        )
+        self.sitemaps_view_name = (
+            sitemaps_view_name
+            if sitemaps_view_name is not None
+            else getattr(
+                settings,
+                'SITEMAPS_VIEW_NAME',
+                'django.contrib.sitemaps.views.sitemap',
+            )
+        )
+        self.sitemaps = (
+            sitemaps
+            if sitemaps is not None
+            else import_string(settings.SITEMAP_MAPPING)
+        )
         self.recorder = ResponseRecorder(
             basehttp.get_internal_wsgi_application())
 
@@ -129,7 +150,7 @@ class SitemapGenerator:
 
     def generate_pages(self, section: str, sitemap: Sitemap):
         """ Generate sitemap section pages."""
-        url = reverse('django.contrib.sitemaps.views.sitemap',
+        url = reverse(self.sitemaps_view_name,
                       kwargs={'section': section})
         for page in sitemap.paginator.page_range:
             if page > 1:

--- a/sitemap_generate/management/commands/generate_sitemap.py
+++ b/sitemap_generate/management/commands/generate_sitemap.py
@@ -8,12 +8,10 @@ from sitemap_generate.generator import SitemapGenerator
 class Command(BaseCommand):
     help = "generate sitemap xml files"
 
-    sitemaps = import_string(settings.SITEMAP_MAPPING)
-
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument('sitemap', type=str, nargs='?')
 
     def handle(self, *args, **options):
-        generator = SitemapGenerator(sitemaps=self.sitemaps)
+        generator = SitemapGenerator()
         generator.generate(options.get('sitemap'))


### PR DESCRIPTION
- Add SITEMAPS_VIEW_NAME setting to also specify sitemap views from
  instead of hardcoded 'django.contrib.sitemaps.views.sitemap'
- Move `load_string` for SITEMAP_MAPPING to `SitemapGenerator`
- Keep old values as defaults